### PR TITLE
Addition of getNetworkSetId method to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.classpath
 .settings/*
+/nbproject/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: clean clean-test clean-pyc clean-build docs help
+.DEFAULT_GOAL := help
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+try:
+	from urllib import pathname2url
+except:
+	from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+clean: ## run mvn clean
+	mvn clean
+	/bin/rm -rf dist
+
+lint: ## check style with checkstyle:checkstyle
+	mvn checkstyle:checkstyle
+
+test: ## run tests with mvn test
+	mvn test
+
+coverage: ## check code coverage with jacoco
+	mvn test jacoco:report
+	$(BROWSER) target/site/jacoco/index.html
+
+install: clean ## install the package to local repo
+	mvn install
+
+updateversion: ## updates version in pom.xml via maven command
+	mvn versions:set

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,21 @@
 	</distributionManagement>
 
 	<build>
-		<plugins>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.3</version>
+                    <executions>
+                        <execution>
+                            <id>prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                    
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
@@ -117,7 +131,18 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
-
+                <dependency>
+                        <groupId>org.easymock</groupId>
+                        <artifactId>easymock</artifactId>
+                        <version>4.0.2</version>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.objenesis</groupId>
+                        <artifactId>objenesis</artifactId>
+                        <version>3.0.1</version>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
@@ -147,5 +172,20 @@
 
 
 	</dependencies>
-
+    <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <!-- select non-aggregate reports -->
+                            <report>report</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
 </project>

--- a/src/main/java/org/ndexbio/rest/client/NdexRestClientModelAccessLayer.java
+++ b/src/main/java/org/ndexbio/rest/client/NdexRestClientModelAccessLayer.java
@@ -81,11 +81,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.ndexbio.model.object.NetworkSet;
 
 /**
+ * Provides wrapper methods for NDEx REST server api. 
+ * 
+ * For more information about the api visit: http://ndexbio.org
  * 
  * @author chenjing
- *
  */
 public class NdexRestClientModelAccessLayer 
 {
@@ -112,7 +115,7 @@ public class NdexRestClientModelAccessLayer
 	 */
 	
 	/**
-	 * Get the client attached to the this data acess object.
+	 * Get the client attached to the this data access object.
 	 * @return
 	 */
 	public NdexRestClient getNdexRestClient() { return ndexRestClient; }
@@ -392,6 +395,41 @@ public class NdexRestClientModelAccessLayer
 				//SolrSearchResult.class);
 	}
 	
+        /* ----------------------------------------
+         *
+         *          Network Set
+         *
+         * ----------------------------------------
+         */
+        
+        /**
+         * 
+         * @param networkSetId id of network set
+         * @param accessKey optional key that allows any user to have read 
+         *                  access to this network set regardless if that user 
+         *                  has the READ privilege on this network. The access
+         *                  key function must be enabled. 
+         * @return NetworkSet object upon success otherwise null
+         * @throws IOException if there was an error with query
+         * @throws NdexException if there was an error with query
+         * @throws IllegalArgumentException if networkSetId is null
+         */
+        public NetworkSet getNetworkSetById(UUID networkSetId, 
+                                            final String accessKey) throws IllegalArgumentException, 
+                IOException, NdexException {
+            
+            if (networkSetId == null){
+                throw new IllegalArgumentException("networkSetId is null");
+            }
+            String query = "";
+            if (accessKey != null){
+                query = "?accesskey=" + accessKey;
+            }
+            return (NetworkSet) ndexRestClient.getNdexObject("/networkset/"+networkSetId,
+                                                             query, NetworkSet.class);
+	}
+        
+        
 	/*-----------------------------------------
 	 * 
 	 *          Network

--- a/src/test/java/org/ndexbio/rest/client/NdexRestClientModelAccessLayerTest.java
+++ b/src/test/java/org/ndexbio/rest/client/NdexRestClientModelAccessLayerTest.java
@@ -1,0 +1,92 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.ndexbio.rest.client;
+
+import java.io.IOException;
+import java.util.UUID;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.ndexbio.model.exceptions.NdexException;
+import org.ndexbio.model.object.NetworkSet;
+
+/**
+ *
+ * @author churas
+ */
+public class NdexRestClientModelAccessLayerTest {
+    
+    public NdexRestClientModelAccessLayerTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void test_getNetworkSetByIdPassingNullId() throws IOException, NdexException {
+        NdexRestClientModelAccessLayer ndex = new NdexRestClientModelAccessLayer(null);
+        try {
+            ndex.getNetworkSetById(null, null);
+            fail("Expected IllegalArgumentException");
+            
+        } catch(IllegalArgumentException iae){
+            assertTrue(iae.getMessage().equals("networkSetId is null"));
+        }
+    }
+    
+    @Test
+    public void test_getNetworkSetByIdNoAccessKeySuccess() throws IOException, NdexException {
+        NdexRestClient mock = mock(NdexRestClient.class);
+        UUID id = UUID.fromString("E2AE10B4-DFBA-4A15-BDB1-91C2257E12AC");
+        NetworkSet myset = new NetworkSet();
+        myset.setName("hi");
+        expect(mock.getNdexObject("/networkset/" + id.toString(), "", NetworkSet.class)).andReturn(myset);
+        replay(mock);
+        NdexRestClientModelAccessLayer ndex = new NdexRestClientModelAccessLayer(mock);
+        
+        NetworkSet res = ndex.getNetworkSetById(id, null);
+        assertTrue(res.getName().equals(myset.getName()));
+        verify(mock);
+            
+    }
+
+    @Test
+    public void test_getNetworkSetByIdWithAccessKeySuccess() throws IOException, NdexException {
+        NdexRestClient mock = mock(NdexRestClient.class);
+        UUID id = UUID.fromString("E2AE10B4-DFBA-4A15-BDB1-91C2257E12AC");
+        NetworkSet myset = new NetworkSet();
+        myset.setName("hi");
+        expect(mock.getNdexObject("/networkset/" + id.toString(), "?accesskey=somekey",
+                                  NetworkSet.class)).andReturn(myset);
+        replay(mock);
+        NdexRestClientModelAccessLayer ndex = new NdexRestClientModelAccessLayer(mock);
+        
+        NetworkSet res = ndex.getNetworkSetById(id, "somekey");
+        assertTrue(res.getName().equals(myset.getName()));
+        verify(mock);
+            
+    }    
+}


### PR DESCRIPTION
The main change in this pull request is addition of getNetworkSetId() method which is needed by enrichment service. There is also an inclusion of a Makefile which provides standardized way to call the usual build targets. Also modified pom.xml to include code coverage along with easy mock